### PR TITLE
Added current tab saver

### DIFF
--- a/conductor/include/gui/control_window.h
+++ b/conductor/include/gui/control_window.h
@@ -16,11 +16,13 @@ void controls_add(GtkBox *controls_box, options *option, GtkNotebook *tab);
 
 void about_info_add(GtkGrid *grid);
 
-void tab_decklink_cb(GtkButton *button, GtkNotebook *tab);
+void tab_decklink_cb(GtkButton *button, options *option);
 
-void tab_webview_cb(GtkButton *button, GtkNotebook *tab);
+void tab_webview_cb(GtkButton *button, options *option);
 
-void tab_nextpage_cb(GtkButton *button, GtkNotebook *tab);
+void tab_nextpage_cb(GtkButton *button, options *option);
+
+void save_current_tab(int tab, options *option);
 
 void decklink_input_hdmi(GtkButton *button, decklink_options *option);
 

--- a/conductor/include/gui/control_window.h
+++ b/conductor/include/gui/control_window.h
@@ -6,21 +6,23 @@
 #include "gui/window.h"
 #include "options.h"
 
-void control_window_init(GtkWidget *window, options *option, GtkNotebook *tab);
+void control_window_init(GtkWidget *window, options *option);
 
 void projector_settings_add(GtkGrid *decklink_options, options *option);
 
 void video_stream_control_add(GtkGrid *projector_options, options *option);
 
-void controls_add(GtkBox *controls_box, options *option, GtkNotebook *tab);
+void controls_add(GtkBox *controls_box, options *option);
 
 void about_info_add(GtkGrid *grid);
 
-void tab_decklink_cb(GtkButton *button, GtkNotebook *tab);
+void tab_decklink_cb(GtkButton *button, options *option);
 
-void tab_webview_cb(GtkButton *button, GtkNotebook *tab);
+void tab_webview_cb(GtkButton *button, options *option);
 
-void tab_nextpage_cb(GtkButton *button, GtkNotebook *tab);
+void tab_nextpage_cb(GtkButton *button, options *option);
+
+void save_current_tab(int tab, options *option);
 
 void decklink_input_hdmi(GtkButton *button, decklink_options *option);
 

--- a/conductor/include/gui/display_window.h
+++ b/conductor/include/gui/display_window.h
@@ -13,6 +13,8 @@ void display_close_cb (GtkWidget *widget, GdkEvent *event, options *option);
 
 void switch_tab_cb(GtkNotebook *notebook, GtkWidget *page, guint page_num, options *option);
 
+int load_current_page_setting(options *option);
+
 void finish();
 
 

--- a/conductor/include/options.h
+++ b/conductor/include/options.h
@@ -7,8 +7,8 @@
 #include <libconfig.h>
 
 #define VERSION_MAJOR 0
-#define VERSION_MINOR 4
-#define VERSION_PATCH 1
+#define VERSION_MINOR 5
+#define VERSION_PATCH 0
 
 #define MAIN_WINDOW "LED Server - Control window"
 #define DISPLAY_WINDOW "LED Server - Display window"

--- a/conductor/src/gui/control_window.c
+++ b/conductor/src/gui/control_window.c
@@ -8,7 +8,7 @@ void control_window_init(GtkWidget *window, options *option, GtkNotebook *tab) {
 
     option->control_window = GTK_WINDOW(window);
 
-    option->display_window = GTK_WINDOW(gtk_widget_get_window(GTK_WIDGET(tab)));
+    option->display_window = GTK_WINDOW(gtk_widget_get_window(GTK_WIDGET(option->m_display_settings->tab)));
     option->m_controls->locked = FALSE;
 
     GtkBox *vbox, *controls_box;
@@ -40,7 +40,7 @@ void control_window_init(GtkWidget *window, options *option, GtkNotebook *tab) {
     gtk_box_pack_start(vbox, GTK_WIDGET(webview_label), FALSE, FALSE, 0);
     gtk_box_pack_start(vbox, GTK_WIDGET(projector_options), TRUE, TRUE, 0);
 
-    controls_add(controls_box, option, tab);
+    controls_add(controls_box, option, option->m_display_settings->tab);
     gtk_box_pack_start(vbox, GTK_WIDGET(controls_label), FALSE, FALSE, 0);
     gtk_box_pack_start(vbox, GTK_WIDGET(controls_box), TRUE, TRUE, 0);
 
@@ -167,9 +167,9 @@ void controls_add(GtkBox *controls_box, options *option, GtkNotebook *tab) {
 
     g_object_set(controls_box, "margin-bottom", 12, NULL);
 
-    g_signal_connect(G_OBJECT(option->m_controls->btn_decklink), "clicked", G_CALLBACK(tab_decklink_cb), tab);
-    g_signal_connect(G_OBJECT(option->m_controls->btn_webview), "clicked", G_CALLBACK(tab_webview_cb), tab);
-    g_signal_connect(G_OBJECT(option->m_controls->btn_tab_switch), "clicked", G_CALLBACK(tab_nextpage_cb), tab);
+    g_signal_connect(G_OBJECT(option->m_controls->btn_decklink), "clicked", G_CALLBACK(tab_decklink_cb), option);
+    g_signal_connect(G_OBJECT(option->m_controls->btn_webview), "clicked", G_CALLBACK(tab_webview_cb), option);
+    g_signal_connect(G_OBJECT(option->m_controls->btn_tab_switch), "clicked", G_CALLBACK(tab_nextpage_cb), option);
     g_signal_connect(G_OBJECT(option->m_controls->btn_open_display), "clicked", G_CALLBACK(open_display_window_cb), option);
     g_signal_connect(G_OBJECT(btn_lock), "clicked", G_CALLBACK(gui_lock_cb), option);
 }
@@ -189,22 +189,45 @@ void about_info_add(GtkGrid *grid) {
 //
 // Callbacks
 //
-void tab_decklink_cb(GtkButton *button, GtkNotebook *tab) {
+void tab_decklink_cb(GtkButton *button, options *option) {
     UNUSED(button);
-    gtk_notebook_set_current_page(tab, 0);
+    gtk_notebook_set_current_page(option->m_display_settings->tab, 0);
+    save_current_tab(0, option);
 }
 
-void tab_webview_cb(GtkButton *button, GtkNotebook *tab) {
+void tab_webview_cb(GtkButton *button, options *option) {
     UNUSED(button);
-    gtk_notebook_set_current_page(tab, 1);
+    gtk_notebook_set_current_page(option->m_display_settings->tab, 1);
+    save_current_tab(1, option);
 }
 
-void tab_nextpage_cb(GtkButton *button, GtkNotebook *tab) {
-    UNUSED(button);
-    if (gtk_notebook_get_current_page(tab) == gtk_notebook_get_n_pages(tab) - 1) {
-        gtk_notebook_set_current_page(tab, 0);
+void save_current_tab(int tab, options *option) {
+    config_setting_t *root, *setting;
+    root = config_root_setting(&option->cfg);
+
+    setting = config_lookup(&option->cfg, "tab");
+    if (!setting) {
+        setting = config_setting_add(root, "tab", CONFIG_TYPE_INT);
+        config_setting_set_int(setting, tab);
+        FILE *file = fopen(option->file_cfg, "w+");
+        config_write(&option->cfg, file);
+        fclose(file);
     } else {
-        gtk_notebook_next_page(tab);
+        config_setting_set_int(setting, tab);
+        FILE *file = fopen(option->file_cfg, "w+");
+        config_write(&option->cfg, file);
+        fclose(file);
+    }
+}
+
+void tab_nextpage_cb(GtkButton *button, options *option) {
+    UNUSED(button);
+    if (gtk_notebook_get_current_page(option->m_display_settings->tab) == gtk_notebook_get_n_pages(option->m_display_settings->tab) - 1) {
+        gtk_notebook_set_current_page(option->m_display_settings->tab, 0);
+        save_current_tab(0, option);
+    } else {
+        gtk_notebook_next_page(option->m_display_settings->tab);
+        save_current_tab(gtk_notebook_get_current_page(option->m_display_settings->tab), option);
     }
 }
 

--- a/conductor/src/gui/display_window.c
+++ b/conductor/src/gui/display_window.c
@@ -3,6 +3,9 @@
 #include "gui/webview.h"
 #include "auxiliary.h"
 
+#include <libconfig.h>
+#include <glib.h>
+typedef void (*FPtr)(void);
 void display_window_init(GtkWidget *window, options *option) {
     GtkNotebook *tab = option->m_display_settings->tab;
 
@@ -55,6 +58,9 @@ void display_close_cb(GtkWidget *widget, GdkEvent *event, options *option) {
     gtk_widget_destroy(widget);
     webview_close_cb(option->m_display_settings->webview, widget);
     gtk_widget_set_sensitive(GTK_WIDGET(option->m_controls->btn_open_display), TRUE);
+
+    // TODO: Remove compiler warning.
+    g_signal_handlers_disconnect_by_func(option->m_controls->btn_tab_switch, tab_nextpage_cb, option);
     printf("Closed: Display Window\n");
 }
 
@@ -78,4 +84,22 @@ void switch_tab_cb(GtkNotebook *notebook, GtkWidget *page, guint page_num, optio
 
 void finish() {
     printf("Script done\n");
+}
+
+int load_current_page_setting(options *option) {
+    config_setting_t *root, *setting;
+    int tab;
+    root = config_root_setting(&option->cfg);
+
+    setting = config_lookup(&option->cfg, "tab");
+    if (!setting) {
+        setting = config_setting_add(root, "tab", CONFIG_TYPE_INT);
+        config_setting_set_int(setting, 0);
+        FILE *file = fopen(option->file_cfg, "w+");
+        config_write(&option->cfg, file);
+        fclose(file);
+    }
+    config_lookup_int(&option->cfg, "tab", &tab);
+
+    return tab;
 }

--- a/conductor/src/gui/display_window.c
+++ b/conductor/src/gui/display_window.c
@@ -3,6 +3,8 @@
 #include "gui/webview.h"
 #include "auxiliary.h"
 
+#include <libconfig.h>
+
 void display_window_init(GtkWidget *window, options *option) {
     GtkNotebook *tab = option->m_display_settings->tab;
 
@@ -45,6 +47,8 @@ void display_window_init(GtkWidget *window, options *option) {
 
     gtk_widget_show_all(window);
 
+    gtk_notebook_set_current_page(tab, load_current_page_setting(option));
+
     gtk_window_move(GTK_WINDOW(window), option->m_display_settings->pos_x, option->m_display_settings->pos_y);
 }
 
@@ -78,4 +82,22 @@ void switch_tab_cb(GtkNotebook *notebook, GtkWidget *page, guint page_num, optio
 
 void finish() {
     printf("Script done\n");
+}
+
+int load_current_page_setting(options *option) {
+    config_setting_t *root, *setting;
+    int tab;
+    root = config_root_setting(&option->cfg);
+
+    setting = config_lookup(&option->cfg, "tab");
+    if (!setting) {
+        setting = config_setting_add(root, "tab", CONFIG_TYPE_INT);
+        config_setting_set_int(setting, 0);
+        FILE *file = fopen(option->file_cfg, "w+");
+        config_write(&option->cfg, file);
+        fclose(file);
+    }
+    config_lookup_int(&option->cfg, "tab", &tab);
+
+    return tab;
 }

--- a/conductor/src/gui/window.c
+++ b/conductor/src/gui/window.c
@@ -33,7 +33,6 @@ void activate(GtkApplication *app, gpointer user_data) {
     } else {
         GtkWidget *display_window;
         GtkWidget *control_window;
-        GtkNotebook *tab;
         stream_data stream;
         config_setting_t *setting, *root;
 
@@ -85,13 +84,12 @@ void activate(GtkApplication *app, gpointer user_data) {
         }
 
         option->m_display_settings->tab = GTK_NOTEBOOK(gtk_notebook_new());
-        tab = option->m_display_settings->tab;
 
         control_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
         display_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
         option->is_display_open = TRUE;
-        control_window_init(control_window, option, tab);
+        control_window_init(control_window, option);
         display_window_init(display_window, option);
 
         gtk_window_set_application(GTK_WINDOW(control_window), app);


### PR DESCRIPTION
This change adds a new feature, where it saves which page the tab was last on. Every time the display window is switched between either webview or gstreamer, it will save that state to conductor.cfg.
